### PR TITLE
add develop option to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ reset: kill install
 start: ## Start the project
 	$(DOCKER_COMPOSE) start
 
+develop: ## Start the project showing logs
+	$(DOCKER_COMPOSE) up
+
 stop: ## Stop the project
 	$(DOCKER_COMPOSE) stop
 
@@ -37,7 +40,7 @@ yarn-build: ## Build and deploy project on your host
 deploy:
 	yarn deploy
 
-.PHONY: kill install reset start stop clean deploy no-docker
+.PHONY: kill install reset start stop clean deploy no-docker build develop
 
 .DEFAULT_GOAL := help
 help:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 LePetitBloc Website
 
+## Development
+``` 
+make develop
+```
+
 ## Code of conduct
 
 See the [CODE OF CONDUCT](CODE_OF_CONDUCT.md) file.


### PR DESCRIPTION
add develop option to Makefile

## Description
Add a develop option to the Makefile to start the container and attach to stdout. 

## Related Issue
#9 

## Motivation and Context
See #9 

## How Has This Been Tested?
Run ```make develop``` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
