### PR TITLE
Better fix for #9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 DOCKER_COMPOSE = docker-compose
+DOCKER_ENV ?= prod
+
 YARN = $(DOCKER_COMPOSE) exec app yarn
 
 ##
@@ -6,8 +8,8 @@ YARN = $(DOCKER_COMPOSE) exec app yarn
 ##-------
 ##
 
-build:
-	$(DOCKER_COMPOSE) up -d --build
+build: ## Build the project
+	$(DOCKER_COMPOSE) build
 
 kill:
 	$(DOCKER_COMPOSE) stop
@@ -21,10 +23,11 @@ reset: ## Stop and start a fresh install of the project
 reset: kill install
 
 start: ## Start the project
-	$(DOCKER_COMPOSE) start
-
-develop: ## Start the project showing logs
+ifeq ($(DOCKER_ENV), prod)
+	$(DOCKER_COMPOSE) up -d
+else
 	$(DOCKER_COMPOSE) up
+endif
 
 stop: ## Stop the project
 	$(DOCKER_COMPOSE) stop
@@ -40,7 +43,10 @@ yarn-build: ## Build and deploy project on your host
 deploy:
 	yarn deploy
 
-.PHONY: kill install reset start stop clean deploy no-docker build develop
+docker-logs: ## Read the docker logs
+	$(DOCKER_COMPOSE) logs -f
+
+.PHONY: kill install reset start stop clean deploy no-docker build
 
 .DEFAULT_GOAL := help
 help:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 LePetitBloc Website
 
 ## Development
-``` 
-make develop
+
+If you want to run docker in dev (for reading log output for example), set `DOCKER_ENV` env variables to `dev`.
+
+```
+export DOCKER_ENV=dev
 ```
 
 ## Code of conduct


### PR DESCRIPTION
Enhance #9 (already merged in #12)
 
## Description
#12 fix some line of code but with incorrect changes :

64a9f1a change `Makefile` because the issue is #9 is for reading log output. The correct way to read logs in docker-compose is `docker-compose logs [container]` or `docker-compose logs [container] -f` if you want to follow the logs output.

Second problem, the `make build` task "build" with `docker-compose up -d --build`, the `make develop` task use `docker-compose up` without build.

Third problem, the conflict with `make build` and `make install`. I fix this one with a real `docker-compose build` for `build` and `docker-compose up [-d]` for `start`.